### PR TITLE
Add periphery contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/ethereum-vault-connector"]
+	path = lib/ethereum-vault-connector
+	url = https://github.com/euler-xyz/ethereum-vault-connector

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,23 @@
+{
+  "lib/erc4626-tests": {
+    "rev": "232ff9ba8194e406967f52ecc5cb52ed764209e9"
+  },
+  "lib/ethereum-vault-connector": {
+    "tag": {
+      "name": "v1.0.1",
+      "rev": "a7d3c29ef7e4964736e47675e0588630d6afbfd7"
+    }
+  },
+  "lib/forge-std": {
+    "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "c64a1edb67b6e3f4a15cca8909c9482ad33a02b0"
+  },
+  "lib/solady": {
+    "rev": "a5bb996e91aae5b0c068087af7594d92068b12f1"
+  },
+  "lib/v4-periphery": {
+    "rev": "ad04c9f24a170accf5ea1b2836bbafd514537ca6"
+  }
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
 @uniswap/v4-core/=lib/v4-periphery/lib/v4-core/
 solmate=lib/v4-periphery/lib/permit2/lib/solmate/
 @aave-v3-core=node_modules/@aave/core-v3/contracts
+ethereum-vault-connector/=lib/ethereum-vault-connector/src/

--- a/src/interfaces/IHookEvents.sol
+++ b/src/interfaces/IHookEvents.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Uniswap Hooks (last updated v0.1.0) (src/interfaces/IHookEvents.sol)
+
+pragma solidity ^0.8.24;
+
+/**
+ * @dev Interface for standard hook events emission.
+ *
+ * NOTE: Hooks should inherit from this interface to standardized event emission.
+ */
+interface IHookEvents {
+    /**
+     * @dev Emitted when a hook executes a swap outside of Uniswap's default concentrated liquidity AMM in a pool
+     * identified by `poolId`, being `sender` the initiator of the swap, `amount0` and `amount1` the swap amounts
+     * (positive for input, negative for output), and `hookLPfeeAmount0`, `hookLPfeeAmount1` the LP fees.
+     */
+    event HookSwap(
+        bytes32 indexed poolId,
+        address indexed sender,
+        int128 amount0,
+        int128 amount1,
+        uint128 hookLPfeeAmount0,
+        uint128 hookLPfeeAmount1
+    );
+
+    /**
+     * @dev Emitted when a hook charges fees in a pool identified by `poolId`, being `sender` the initiator of the swap or
+     * the liquidity modifier, `feeAmount0` and `feeAmount1` the fees charged in currency0 and currency1, defined by the `poolId`.
+     */
+    event HookFee(bytes32 indexed poolId, address indexed sender, uint128 feeAmount0, uint128 feeAmount1);
+
+    /**
+     * @dev Emitted when a liquidity modification is executed in a pool identified by `poolId`, being `sender` the liquidity modifier,
+     * `amount0` and `amount1` the amounts added or removed in currency0 and currency1, defined by the `poolId`.
+     */
+    event HookModifyLiquidity(bytes32 indexed poolId, address indexed sender, int128 amount0, int128 amount1);
+
+    /**
+     * @dev Emitted when a bonus is added to an operation in a pool identified by `poolId`, being `amount0` and `amount1` the amounts
+     * added in currency0 and currency1, defined by the `poolId`.
+     */
+    event HookBonus(bytes32 indexed poolId, uint128 amount0, uint128 amount1);
+}

--- a/src/periphery/AssetToAssetSwapHookForERC4626.sol
+++ b/src/periphery/AssetToAssetSwapHookForERC4626.sol
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.26;
+
+import {BaseHook} from "v4-periphery/src/utils/BaseHook.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {IERC4626} from "lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+import {SafeERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {
+    BeforeSwapDelta, BeforeSwapDeltaLibrary, toBeforeSwapDelta
+} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+import {IPoolManager, ModifyLiquidityParams, SwapParams} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {SafeCast} from "lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+import {IHookEvents} from "src/interfaces/IHookEvents.sol";
+import {IPositionManager} from "lib/v4-periphery/src/interfaces/IPositionManager.sol";
+import {EVCUtil, LiquidityHelper} from "src/periphery/LiquidityHelper.sol";
+import {Ownable} from "lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+import {Context} from "lib/openzeppelin-contracts/contracts/utils/Context.sol";
+import {BaseAssetToVaultWrapperHelper} from "src/periphery/base/BaseAssetToVaultWrapperHelper.sol";
+
+/// @notice This contract enables users to interact with pools created using the yield harvesting hook without needing to manually convert assets to or from vault wrappers.
+/// @dev It automates the conversion between ERC20 assets without any special logic, following the flow described in https://github.com/VII-Finance/yield-harvesting-hook/blob/periphery-contracts/docs/swap_flow.md.
+/// @dev Only vault wrappers with underlying vaults that support the ERC4626 interface are supported; Aave vaults are not supported.
+/// @dev hookData should contain two encoded IERC4626 vault wrappers (for token0 and token1 respectively), or address(0) if no vault wrapper is used for that token
+/// @dev if hookDat is not provided then default vault wrappers decided by the hook owner will be used.
+contract AssetToAssetSwapHookForERC4626 is BaseHook, BaseAssetToVaultWrapperHelper, Ownable, IHookEvents {
+    using SafeERC20 for IERC20;
+    using SafeCast for uint256;
+    using SafeCast for int256;
+    using SafeCast for int128;
+
+    struct VaultWrappers {
+        IERC4626 vaultWrapperForCurrency0;
+        IERC4626 vaultWrapperForCurrency1;
+    }
+
+    /// @notice The hooks contract for vault wrapper pools
+    IHooks public immutable yieldHarvestingHook;
+
+    mapping(PoolId poolId => VaultWrappers vaultWrappers) public defaultVaultWrappers;
+
+    event DefaultVaultWrappersSet(
+        bytes32 indexed poolId, address indexed vaultWrappers0, address indexed vaultWrapperForCurrency1
+    );
+
+    constructor(IPoolManager _poolManager, IHooks _yieldHarvestingHook, address _initialOwner)
+        BaseHook(_poolManager)
+        Ownable(_initialOwner)
+    {
+        yieldHarvestingHook = _yieldHarvestingHook;
+    }
+
+    function _beforeSwap(address sender, PoolKey calldata key, SwapParams calldata params, bytes calldata hookData)
+        internal
+        override
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        bool isExactInput = params.amountSpecified < 0;
+
+        SwapContext memory context = _initializeSwapContext(key, params, hookData);
+
+        uint256 amountIn;
+        uint256 amountOut;
+
+        if (isExactInput) {
+            (amountIn, amountOut) = _handleExactInputSwap(context, params);
+
+            emit HookSwap(
+                PoolId.unwrap(key.toId()),
+                sender,
+                params.zeroForOne ? amountIn.toInt256().toInt128() : -amountOut.toInt256().toInt128(),
+                params.zeroForOne ? -amountOut.toInt256().toInt128() : amountIn.toInt256().toInt128(),
+                0,
+                0
+            );
+        } else {
+            (amountIn, amountOut) = _handleExactOutputSwap(context, params);
+
+            emit HookSwap(
+                PoolId.unwrap(key.toId()),
+                sender,
+                params.zeroForOne ? -amountIn.toInt256().toInt128() : amountOut.toInt256().toInt128(),
+                params.zeroForOne ? amountOut.toInt256().toInt128() : -amountIn.toInt256().toInt128(),
+                0,
+                0
+            );
+        }
+
+        BeforeSwapDelta returnDelta = _calculateReturnDelta(isExactInput, amountIn, amountOut);
+
+        return (BaseHook.beforeSwap.selector, returnDelta, 0);
+    }
+
+    /// @dev Struct to hold swap context data
+    struct SwapContext {
+        IERC4626 vaultWrapperIn;
+        IERC4626 vaultWrapperOut;
+        IERC4626 underlyingVaultIn;
+        IERC4626 underlyingVaultOut;
+        IERC20 assetIn;
+        IERC20 assetOut;
+        PoolKey vaultWrapperPoolKey;
+    }
+
+    /// @dev Initialize swap context with vault wrappers and assets
+    function _initializeSwapContext(PoolKey calldata key, SwapParams calldata params, bytes calldata hookData)
+        private
+        view
+        returns (SwapContext memory context)
+    {
+        IERC4626 vaultWrapperForCurrency0;
+        IERC4626 vaultWrapperForCurrency1;
+
+        //if vault wrappers to use is not provided than the contract will simply use defaults set by owner
+        if (hookData.length > 0) {
+            (vaultWrapperForCurrency0, vaultWrapperForCurrency1) = abi.decode(hookData, (IERC4626, IERC4626));
+        } else {
+            VaultWrappers memory defaultVaultWrappersSetByOwner = defaultVaultWrappers[key.toId()];
+            (vaultWrapperForCurrency0, vaultWrapperForCurrency1) = (
+                defaultVaultWrappersSetByOwner.vaultWrapperForCurrency0,
+                defaultVaultWrappersSetByOwner.vaultWrapperForCurrency1
+            );
+        }
+
+        IERC4626 underlyingVault0 = _getUnderlyingVault(vaultWrapperForCurrency0);
+        IERC4626 underlyingVault1 = _getUnderlyingVault(vaultWrapperForCurrency1);
+
+        try vaultWrapperForCurrency1.asset() returns (address asset1) {
+            underlyingVault1 = IERC4626(asset1);
+        } catch {
+            underlyingVault1 = IERC4626(address(0));
+        }
+
+        (context.vaultWrapperIn, context.vaultWrapperOut) = params.zeroForOne
+            ? (vaultWrapperForCurrency0, vaultWrapperForCurrency1)
+            : (vaultWrapperForCurrency1, vaultWrapperForCurrency0);
+
+        (context.underlyingVaultIn, context.underlyingVaultOut) =
+            params.zeroForOne ? (underlyingVault0, underlyingVault1) : (underlyingVault1, underlyingVault0);
+
+        context.assetIn =
+            params.zeroForOne ? IERC20(Currency.unwrap(key.currency0)) : IERC20(Currency.unwrap(key.currency1));
+        context.assetOut =
+            params.zeroForOne ? IERC20(Currency.unwrap(key.currency1)) : IERC20(Currency.unwrap(key.currency0));
+
+        context.vaultWrapperPoolKey = PoolKey({
+            currency0: address(vaultWrapperForCurrency0) < address(vaultWrapperForCurrency1)
+                ? Currency.wrap(address(vaultWrapperForCurrency0))
+                : Currency.wrap(address(vaultWrapperForCurrency1)),
+            currency1: address(vaultWrapperForCurrency0) < address(vaultWrapperForCurrency1)
+                ? Currency.wrap(address(vaultWrapperForCurrency1))
+                : Currency.wrap(address(vaultWrapperForCurrency0)),
+            fee: key.fee,
+            tickSpacing: key.tickSpacing,
+            hooks: yieldHarvestingHook
+        });
+    }
+
+    /// @dev Handle exact input swap: user specifies input amount, gets variable output
+    function _handleExactInputSwap(SwapContext memory context, SwapParams calldata params)
+        private
+        returns (uint256 amountIn, uint256 amountOut)
+    {
+        amountIn = (-params.amountSpecified).toUint256();
+
+        // Take input tokens from pool manager
+        poolManager.take(Currency.wrap(address(context.assetIn)), address(this), amountIn);
+
+        // Convert input asset to vault wrapper shares and send to the PoolManager
+        uint256 vaultWrapperSharesMinted =
+            _convertAssetToVaultWrapper(context.assetIn, context.underlyingVaultIn, context.vaultWrapperIn, amountIn);
+
+        // Swap vault wrapper shares
+        uint256 vaultWrapperOutAmount = _performVaultWrapperSwap(
+            context.vaultWrapperPoolKey,
+            params,
+            vaultWrapperSharesMinted,
+            true // isExactInput
+        );
+
+        // Take output vault wrapper shares from pool manager
+        poolManager.take(Currency.wrap(address(context.vaultWrapperOut)), address(this), vaultWrapperOutAmount);
+
+        // Convert vault wrapper shares to output asset
+        amountOut = _convertVaultWrapperToAsset(
+            context.vaultWrapperOut, context.underlyingVaultOut, context.assetOut, vaultWrapperOutAmount
+        );
+    }
+
+    /// @dev Handle exact output swap: user specifies output amount, pays variable input
+    function _handleExactOutputSwap(SwapContext memory context, SwapParams calldata params)
+        private
+        returns (uint256 amountIn, uint256 amountOut)
+    {
+        amountOut = params.amountSpecified.toUint256();
+
+        // Calculate required vault wrapper shares for desired output
+        uint256 underlyingVaultSharesNeeded = context.underlyingVaultOut.previewWithdraw(amountOut);
+        uint256 vaultWrapperSharesNeeded = context.vaultWrapperOut.previewWithdraw(underlyingVaultSharesNeeded);
+
+        // Perform swap to get required vault wrapper shares
+        uint256 vaultWrapperInAmount = _performVaultWrapperSwap(
+            context.vaultWrapperPoolKey,
+            params,
+            vaultWrapperSharesNeeded,
+            false // isExactInput = false
+        );
+
+        // Take the vault wrapper shares obtained from swap
+        poolManager.take(Currency.wrap(address(context.vaultWrapperOut)), address(this), vaultWrapperSharesNeeded);
+
+        // output assets are withdrawn from vaultWrapperOut and sent to the poolManager so that the original swapper can take it out
+        _withdrawVaultWrapperToAsset(
+            context.vaultWrapperOut, context.underlyingVaultOut, context.assetOut, vaultWrapperSharesNeeded, amountOut
+        );
+
+        // Calculate input amount needed
+        uint256 underlyingVaultSharesNeedIn = context.vaultWrapperIn.previewMint(vaultWrapperInAmount);
+        amountIn = context.underlyingVaultIn.previewMint(underlyingVaultSharesNeedIn);
+
+        // Take input from pool manager and mint vault wrapper shares
+        poolManager.take(Currency.wrap(address(context.assetIn)), address(this), amountIn);
+
+        //vault wrapperIn tokens are minted and settled
+        _mintVaultWrapperShares(
+            context.assetIn, context.underlyingVaultIn, context.vaultWrapperIn, amountIn, vaultWrapperInAmount
+        );
+    }
+
+    /// @dev Calculate the return delta for the swap
+    function _calculateReturnDelta(bool isExactInput, uint256 amountIn, uint256 amountOut)
+        private
+        pure
+        returns (BeforeSwapDelta)
+    {
+        return isExactInput
+            ? toBeforeSwapDelta(amountIn.toInt256().toInt128(), -(amountOut.toInt256().toInt128()))
+            : toBeforeSwapDelta(-(amountOut.toInt256().toInt128()), amountIn.toInt256().toInt128());
+    }
+
+    /// @dev Convert input asset to vault wrapper shares
+    function _convertAssetToVaultWrapper(
+        IERC20 asset,
+        IERC4626 underlyingVault,
+        IERC4626 vaultWrapper,
+        uint256 assetAmount
+    ) private returns (uint256 vaultWrapperShares) {
+        poolManager.sync(Currency.wrap(address(vaultWrapper)));
+        if (address(vaultWrapper) != address(asset)) {
+            vaultWrapperShares = _deposit(
+                vaultWrapper, address(underlyingVault), asset, address(this), assetAmount, address(poolManager)
+            );
+        } else {
+            vaultWrapperShares = assetAmount;
+            SafeERC20.safeTransfer(asset, address(poolManager), assetAmount);
+        }
+        poolManager.settle();
+    }
+
+    /// @dev Perform vault wrapper swap
+    function _performVaultWrapperSwap(
+        PoolKey memory poolKey,
+        SwapParams calldata originalParams,
+        uint256 amount,
+        bool isExactInput
+    ) private returns (uint256 outputAmount) {
+        SwapParams memory swapParams = SwapParams({
+            zeroForOne: originalParams.zeroForOne,
+            amountSpecified: isExactInput ? -amount.toInt256() : amount.toInt256(),
+            sqrtPriceLimitX96: originalParams.sqrtPriceLimitX96
+        });
+
+        BalanceDelta swapDelta = poolManager.swap(poolKey, swapParams, "");
+
+        if (isExactInput) {
+            outputAmount =
+                originalParams.zeroForOne ? (swapDelta.amount1()).toUint256() : (swapDelta.amount0()).toUint256();
+        } else {
+            outputAmount =
+                originalParams.zeroForOne ? (-swapDelta.amount0()).toUint256() : (-swapDelta.amount1()).toUint256();
+        }
+    }
+
+    /// @dev Convert vault wrapper shares to output asset
+    function _convertVaultWrapperToAsset(
+        IERC4626 vaultWrapper,
+        IERC4626 underlyingVault,
+        IERC20 asset,
+        uint256 vaultWrapperAmount
+    ) private returns (uint256 assetAmount) {
+        poolManager.sync(Currency.wrap(address(asset)));
+        if (address(vaultWrapper) != address(asset)) {
+            assetAmount =
+                _redeem(vaultWrapper, address(underlyingVault), address(this), vaultWrapperAmount, address(poolManager));
+        } else {
+            // Transfer asset to the poolManager
+            SafeERC20.safeTransfer(asset, address(poolManager), vaultWrapperAmount);
+            assetAmount = vaultWrapperAmount;
+        }
+        poolManager.settle();
+    }
+
+    /// @dev Mint vault wrapper shares for exact output swaps
+    function _mintVaultWrapperShares(
+        IERC20 asset,
+        IERC4626 underlyingVault,
+        IERC4626 vaultWrapper,
+        uint256 assetAmount,
+        uint256 vaultWrapperAmount
+    ) private {
+        poolManager.sync(Currency.wrap(address(vaultWrapper)));
+
+        if (address(underlyingVault) != address(vaultWrapper)) {
+            _mint(
+                vaultWrapper, address(underlyingVault), asset, address(this), vaultWrapperAmount, address(poolManager)
+            );
+        } else {
+            SafeERC20.safeTransfer(asset, address(poolManager), assetAmount);
+        }
+        poolManager.settle();
+    }
+
+    /// @dev Withdraw vault wrapper shares to asset for exact output swaps
+    function _withdrawVaultWrapperToAsset(
+        IERC4626 vaultWrapper,
+        IERC4626 underlyingVault,
+        IERC20 asset,
+        uint256 vaultWrapperSharesNeeded,
+        uint256 amountOut
+    ) private {
+        poolManager.sync(Currency.wrap(address(asset)));
+
+        if (address(vaultWrapper) != address(asset)) {
+            _withdraw(
+                vaultWrapper, address(underlyingVault), address(this), vaultWrapperSharesNeeded, address(poolManager)
+            );
+        } else {
+            SafeERC20.safeTransfer(asset, address(poolManager), amountOut);
+        }
+        poolManager.settle();
+    }
+
+    function setDefaultVaultWrappers(
+        PoolKey memory assetsPoolKey,
+        IERC4626 vaultWrapperForCurrency0,
+        IERC4626 vaultWrapperForCurrency1
+    ) external onlyOwner {
+        //we expect owner to make sure they sanity check the addresses
+        //address(0) if we expect currency itself to be used without any vaultWrappers
+        PoolId assetsPoolId = assetsPoolKey.toId();
+        defaultVaultWrappers[assetsPoolId] = VaultWrappers({
+            vaultWrapperForCurrency0: vaultWrapperForCurrency0,
+            vaultWrapperForCurrency1: vaultWrapperForCurrency1
+        });
+
+        emit DefaultVaultWrappersSet(
+            PoolId.unwrap(assetsPoolId), address(vaultWrapperForCurrency0), address(vaultWrapperForCurrency1)
+        );
+    }
+
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: false,
+            afterInitialize: false,
+            beforeAddLiquidity: false,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: true,
+            afterSwap: false,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: true,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+}

--- a/src/periphery/LiquidityHelper.sol
+++ b/src/periphery/LiquidityHelper.sol
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.26;
+
+import {IERC4626} from "lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+import {SafeERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
+import {SafeCast} from "lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+import {BaseAssetToVaultWrapperHelper} from "src/periphery/base/BaseAssetToVaultWrapperHelper.sol";
+import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPositionManager} from "lib/v4-periphery/src/interfaces/IPositionManager.sol";
+import {Actions} from "lib/v4-periphery/src/libraries/Actions.sol";
+import {ActionConstants} from "lib/v4-periphery/src/libraries/ActionConstants.sol";
+import {IWETH9} from "lib/v4-periphery/src/interfaces/external/IWETH9.sol";
+
+interface IPositionManagerExtended is IPositionManager {
+    function WETH9() external view returns (address);
+}
+
+///@dev This doesn't support aave vaults. Only vault wrappers that have underlying vaults that support ERC4626 interface are supported
+contract LiquidityHelper is EVCUtil, BaseAssetToVaultWrapperHelper {
+    using SafeERC20 for IERC20;
+    using SafeCast for uint256;
+    using SafeCast for int256;
+    using SafeCast for int128;
+
+    IPositionManager public immutable positionManager;
+    /// @notice The hooks contract for vault wrapper pools
+    IHooks public immutable yieldHarvestingHook;
+    IWETH9 public immutable weth;
+
+    error NotOwner();
+
+    constructor(address _evc, IPositionManager _positionManager, IHooks _yieldHarvestingHook) EVCUtil(_evc) {
+        yieldHarvestingHook = _yieldHarvestingHook;
+        positionManager = _positionManager;
+        weth = IWETH9(IPositionManagerExtended(address(_positionManager)).WETH9());
+    }
+
+    modifier onlyOwnerOf(uint256 tokenId) {
+        if (IERC721(address(positionManager)).ownerOf(tokenId) != _msgSender()) {
+            revert NotOwner();
+        }
+        _;
+    }
+
+    function _pullAndConvertAssets(
+        PoolKey memory poolKey,
+        uint128 amount0Max,
+        uint128 amount1Max,
+        bytes calldata hookData
+    ) internal returns (PoolKey memory) {
+        (IERC4626 vaultWrapper0, IERC4626 vaultWrapper1) = hookData.length == 0
+            ? (IERC4626(address(0)), IERC4626(address(0)))
+            : abi.decode(hookData, (IERC4626, IERC4626));
+        if (amount0Max != 0) {
+            if (!poolKey.currency0.isAddressZero()) {
+                IERC20(Currency.unwrap(poolKey.currency0)).safeTransferFrom(_msgSender(), address(this), amount0Max);
+            } else if (msg.value == 0) {
+                weth.transferFrom(_msgSender(), address(this), amount0Max);
+            }
+        }
+        if (amount1Max != 0) {
+            IERC20(Currency.unwrap(poolKey.currency1)).safeTransferFrom(_msgSender(), address(this), amount1Max);
+        }
+
+        uint256 currentWETHBalance = weth.balanceOf(address(this));
+        if (currentWETHBalance > 0) {
+            weth.withdraw(currentWETHBalance);
+        }
+
+        amount0Max = SafeCast.toUint128(poolKey.currency0.balanceOf(address(this)));
+        amount1Max = SafeCast.toUint128(poolKey.currency1.balanceOf(address(this)));
+
+        if (address(vaultWrapper0) != address(0)) {
+            IERC4626 underlyingVault0 = _getUnderlyingVault(vaultWrapper0);
+            _deposit(
+                vaultWrapper0,
+                address(underlyingVault0),
+                IERC20(Currency.unwrap(poolKey.currency0)),
+                address(this),
+                amount0Max,
+                address(positionManager)
+            );
+            poolKey.currency0 = Currency.wrap(address(vaultWrapper0));
+            poolKey.hooks = yieldHarvestingHook;
+        } else {
+            if (!poolKey.currency0.isAddressZero()) {
+                poolKey.currency0.transfer(address(positionManager), amount0Max);
+            }
+        }
+
+        if (address(vaultWrapper1) != address(0)) {
+            IERC4626 underlyingVault1 = _getUnderlyingVault(vaultWrapper1);
+            _deposit(
+                vaultWrapper1,
+                address(underlyingVault1),
+                IERC20(Currency.unwrap(poolKey.currency1)),
+                address(this),
+                amount1Max,
+                address(positionManager)
+            );
+            poolKey.currency1 = Currency.wrap(address(vaultWrapper1));
+            poolKey.hooks = yieldHarvestingHook;
+        } else {
+            poolKey.currency1.transfer(address(positionManager), amount1Max);
+        }
+
+        //currencies might be out of order at this point, so we need to sort them
+        if (Currency.unwrap(poolKey.currency0) > Currency.unwrap(poolKey.currency1)) {
+            (poolKey.currency0, poolKey.currency1) = (poolKey.currency1, poolKey.currency0);
+        }
+
+        return poolKey;
+    }
+
+    function _callModifyLiquidity(
+        uint8 actionType, // either Actions.MINT_POSITION or Actions.INCREASE_LIQUIDITY
+        bytes memory actionData, // encoded params for first action,
+        PoolKey memory poolKey
+    ) internal {
+        bytes memory actions = new bytes(5);
+        actions[0] = bytes1(actionType);
+        actions[1] = bytes1(uint8(Actions.SETTLE));
+        actions[2] = bytes1(uint8(Actions.SETTLE));
+        actions[3] = bytes1(uint8(Actions.SWEEP));
+        actions[4] = bytes1(uint8(Actions.SWEEP));
+
+        bytes[] memory params = new bytes[](5);
+        params[0] = actionData;
+        params[1] = abi.encode(poolKey.currency0, ActionConstants.OPEN_DELTA, false);
+        params[2] = abi.encode(poolKey.currency1, ActionConstants.OPEN_DELTA, false);
+        params[3] = abi.encode(poolKey.currency0, _msgSender());
+        params[4] = abi.encode(poolKey.currency1, _msgSender());
+
+        positionManager.modifyLiquidities{value: address(this).balance}(abi.encode(actions, params), block.timestamp);
+    }
+
+    function mintPosition(
+        PoolKey memory poolKey,
+        int24 tickLower,
+        int24 tickUpper,
+        uint256 liquidity,
+        uint128 amount0Max,
+        uint128 amount1Max,
+        address owner,
+        bytes calldata hookData
+    ) external payable returns (uint256 tokenId) {
+        tokenId = positionManager.nextTokenId();
+
+        poolKey = _pullAndConvertAssets(poolKey, amount0Max, amount1Max, hookData);
+
+        bytes memory actionData =
+            abi.encode(poolKey, tickLower, tickUpper, liquidity, amount0Max, amount1Max, owner, "");
+
+        _callModifyLiquidity(uint8(Actions.MINT_POSITION), actionData, poolKey);
+    }
+
+    function increaseLiquidity(
+        PoolKey memory poolKey,
+        uint256 tokenId,
+        uint256 liquidity,
+        uint128 amount0Max,
+        uint128 amount1Max,
+        bytes calldata hookData
+    ) external payable onlyOwnerOf(tokenId) {
+        poolKey = _pullAndConvertAssets(poolKey, amount0Max, amount1Max, hookData);
+
+        bytes memory actionData = abi.encode(tokenId, liquidity, amount0Max, amount1Max, "");
+        _callModifyLiquidity(uint8(Actions.INCREASE_LIQUIDITY), actionData, poolKey);
+    }
+
+    function decreaseLiquidity(
+        PoolKey memory poolKey,
+        uint256 tokenId,
+        uint128 liquidity,
+        uint128 amount0Min,
+        uint128 amount1Min,
+        address recipient,
+        bytes calldata hookData
+    ) public onlyOwnerOf(tokenId) {
+        Currency currency0 = poolKey.currency0;
+        Currency currency1 = poolKey.currency1;
+
+        (IERC4626 vaultWrapper0, IERC4626 vaultWrapper1) = hookData.length == 0
+            ? (IERC4626(address(0)), IERC4626(address(0)))
+            : abi.decode(hookData, (IERC4626, IERC4626));
+
+        if (address(vaultWrapper0) != address(0)) {
+            poolKey.currency0 = Currency.wrap(address(vaultWrapper0));
+            poolKey.hooks = yieldHarvestingHook;
+        }
+        if (address(vaultWrapper1) != address(0)) {
+            poolKey.currency1 = Currency.wrap(address(vaultWrapper1));
+            poolKey.hooks = yieldHarvestingHook;
+        }
+
+        if (Currency.unwrap(poolKey.currency0) > Currency.unwrap(poolKey.currency1)) {
+            (poolKey.currency0, poolKey.currency1) = (poolKey.currency1, poolKey.currency0);
+        }
+
+        bytes memory actions = new bytes(2);
+        actions[0] = bytes1(uint8(Actions.DECREASE_LIQUIDITY));
+        actions[1] = bytes1(uint8(Actions.TAKE_PAIR));
+
+        bytes[] memory params = new bytes[](2);
+        params[0] = abi.encode(tokenId, liquidity, amount0Min, amount1Min, "");
+        params[1] = abi.encode(poolKey.currency0, poolKey.currency1, ActionConstants.MSG_SENDER);
+
+        positionManager.modifyLiquidities{value: address(this).balance}(abi.encode(actions, params), block.timestamp);
+
+        //this contract will have the tokens after decreasing liquidity, now we need to withdraw from vault wrappers if needed and send to recipient
+        if (address(vaultWrapper0) != address(0)) {
+            IERC4626 underlyingVault0 = _getUnderlyingVault(vaultWrapper0);
+            _withdraw(
+                vaultWrapper0,
+                address(underlyingVault0),
+                address(this),
+                vaultWrapper0.balanceOf(address(this)),
+                recipient
+            );
+        } else {
+            //simply transfer the tokens to recipient
+            currency0.transfer(recipient, currency0.balanceOfSelf());
+        }
+
+        if (address(vaultWrapper1) != address(0)) {
+            IERC4626 underlyingVault1 = _getUnderlyingVault(vaultWrapper1);
+            _withdraw(
+                vaultWrapper1,
+                address(underlyingVault1),
+                address(this),
+                vaultWrapper1.balanceOf(address(this)),
+                recipient
+            );
+        } else {
+            //simply transfer the tokens to recipient
+            currency1.transfer(recipient, currency1.balanceOfSelf());
+        }
+    }
+
+    function collectFees(
+        PoolKey memory poolKey,
+        uint256 tokenId,
+        uint128 amount0Min,
+        uint128 amount1Min,
+        address recipient,
+        bytes calldata hookData
+    ) external {
+        decreaseLiquidity(poolKey, tokenId, 0, amount0Min, amount1Min, recipient, hookData);
+    }
+}

--- a/src/periphery/base/BaseAssetToVaultWrapperHelper.sol
+++ b/src/periphery/base/BaseAssetToVaultWrapperHelper.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.26;
+
+import {IERC4626} from "lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import {SafeERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract BaseAssetToVaultWrapperHelper {
+    using SafeERC20 for IERC20;
+    using SafeERC20 for IERC4626;
+
+    function _deposit(
+        IERC4626 vaultWrapper,
+        address underlyingVault,
+        IERC20 asset,
+        address from,
+        uint256 amount,
+        address receiver
+    ) internal returns (uint256) {
+        uint256 underlyingVaultShares = _depositInUnderlyingVault(underlyingVault, asset, from, amount, address(this));
+        return _depositIntoERC4626Vault(
+            vaultWrapper, IERC20(underlyingVault), address(this), underlyingVaultShares, receiver
+        );
+    }
+
+    /// @dev for aave wrappers, override this function
+    function _depositInUnderlyingVault(
+        address underlyingVault,
+        IERC20 asset,
+        address from,
+        uint256 amount,
+        address receiver
+    ) internal virtual returns (uint256) {
+        return _depositIntoERC4626Vault(IERC4626(underlyingVault), asset, from, amount, receiver);
+    }
+
+    function _depositIntoERC4626Vault(IERC4626 vault, IERC20 asset, address from, uint256 amount, address receiver)
+        internal
+        returns (uint256)
+    {
+        if (from != address(this)) asset.safeTransferFrom(from, address(this), amount);
+
+        try vault.deposit(amount, receiver) returns (uint256 shares) {
+            return shares;
+        } catch {
+            // If deposit fails, it may have been because of lack of approval
+            asset.forceApprove(address(vault), type(uint256).max);
+            return vault.deposit(amount, receiver);
+        }
+    }
+
+    function _redeem(IERC4626 vaultWrapper, address underlyingVault, address from, uint256 amount, address receiver)
+        internal
+        returns (uint256)
+    {
+        uint256 underlyingVaultShares = _redeemFromERC4626Vault(vaultWrapper, from, amount, address(this));
+        return _redeemFromUnderlyingVault(address(underlyingVault), address(this), underlyingVaultShares, receiver);
+    }
+
+    /// @dev for aave wrapper, override this function
+    function _redeemFromUnderlyingVault(address underlyingVault, address from, uint256 amount, address receiver)
+        internal
+        virtual
+        returns (uint256)
+    {
+        return _redeemFromERC4626Vault(IERC4626(underlyingVault), from, amount, receiver);
+    }
+
+    /// @dev if from!=address(this) then they should have approve address(this) for amount of vault wrapper asset
+    function _redeemFromERC4626Vault(IERC4626 vault, address from, uint256 amount, address receiver)
+        internal
+        returns (uint256)
+    {
+        return vault.redeem(amount, receiver, from);
+    }
+
+    function _mint(
+        IERC4626 vaultWrapper,
+        address underlyingVault,
+        IERC20 asset,
+        address from,
+        uint256 amount,
+        address receiver
+    ) internal returns (uint256 assetAmount) {
+        uint256 underlyingSharesNeeded = vaultWrapper.previewMint(amount);
+        assetAmount = _mintInUnderlyingVault(underlyingVault, asset, from, underlyingSharesNeeded, address(this));
+        _mintERC4626VaultShares(vaultWrapper, IERC20(underlyingVault), address(this), amount, receiver);
+    }
+
+    function _mintInUnderlyingVault(address vault, IERC20 asset, address from, uint256 amount, address receiver)
+        internal
+        virtual
+        returns (uint256)
+    {
+        return _mintERC4626VaultShares(IERC4626(vault), asset, from, amount, receiver);
+    }
+
+    function _mintERC4626VaultShares(IERC4626 vault, IERC20 asset, address from, uint256 amount, address receiver)
+        internal
+        returns (uint256)
+    {
+        if (from != address(this)) asset.safeTransferFrom(from, address(this), vault.previewMint(amount));
+
+        try vault.mint(amount, receiver) returns (uint256 shares) {
+            return shares;
+        } catch {
+            // If mint fails, it may have been because of lack of approval
+            asset.forceApprove(address(vault), type(uint256).max);
+            return vault.mint(amount, receiver);
+        }
+    }
+
+    function _withdraw(IERC4626 vaultWrapper, address underlyingVault, address from, uint256 amount, address receiver)
+        internal
+        returns (uint256 shares)
+    {
+        uint256 underlyingVaultSharesToWithdraw = vaultWrapper.previewWithdraw(amount);
+        shares = _withdrawFromERC4626Vault(vaultWrapper, from, amount, address(this));
+        return _withdrawFromUnderlyingVault(underlyingVault, address(this), underlyingVaultSharesToWithdraw, receiver);
+    }
+
+    function _withdrawFromUnderlyingVault(address underlyingVault, address from, uint256 amount, address receiver)
+        internal
+        virtual
+        returns (uint256)
+    {
+        return _withdrawFromERC4626Vault(IERC4626(underlyingVault), from, amount, receiver);
+    }
+
+    function _withdrawFromERC4626Vault(IERC4626 vault, address from, uint256 amount, address receiver)
+        internal
+        returns (uint256)
+    {
+        return vault.withdraw(amount, receiver, from);
+    }
+
+    function _getUnderlyingVault(IERC4626 vaultWrapper) internal view returns (IERC4626 underlyingVault) {
+        try vaultWrapper.asset() returns (address asset) {
+            underlyingVault = IERC4626(asset);
+        } catch {
+            underlyingVault = IERC4626(address(0));
+        }
+        return underlyingVault;
+    }
+}

--- a/src/vaultWrappers/AaveWrapper.sol
+++ b/src/vaultWrappers/AaveWrapper.sol
@@ -10,7 +10,7 @@ import {BaseVaultWrapper} from "src/vaultWrappers/base/BaseVaultWrapper.sol";
  * @dev Aave does not have bad debt socialization, so this wrapper will always remain solvent.
  */
 contract AaveWrapper is BaseVaultWrapper {
-    constructor() BaseVaultWrapper() {}
+    constructor() {}
 
     function _convertToShares(uint256 assets, Math.Rounding) internal pure override returns (uint256) {
         return assets;

--- a/src/vaultWrappers/ERC4626VaultWrapper.sol
+++ b/src/vaultWrappers/ERC4626VaultWrapper.sol
@@ -15,7 +15,7 @@ import {BaseVaultWrapper} from "src/vaultWrappers/base/BaseVaultWrapper.sol";
  *      No harvest operations will occur until the vault regains solvency.
  */
 contract ERC4626VaultWrapper is BaseVaultWrapper {
-    constructor() BaseVaultWrapper() {}
+    constructor() {}
 
     function previewMint(uint256 shares) public view override returns (uint256) {
         return _underlyingVault().previewWithdraw(shares);

--- a/test/periphery/AssetToAssetSwapHook.sol
+++ b/test/periphery/AssetToAssetSwapHook.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.13;
+
+import {YieldHarvestingHookTest} from "test/YieldHarvestingHook.t.sol";
+import {AssetToAssetSwapHookForERC4626} from "src/periphery/AssetToAssetSwapHookForERC4626.sol";
+import {HookMiner} from "lib/v4-periphery/src/utils/HookMiner.sol";
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Constants} from "@uniswap/v4-core/test/utils/Constants.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {IPoolManager, SwapParams} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {ModifyLiquidityParams, SwapParams} from "lib/v4-periphery/lib/v4-core/src/types/PoolOperation.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {PoolManager} from "@uniswap/v4-core/src/PoolManager.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {SafeCast} from "lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+import {IERC4626} from "lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+import {EthereumVaultConnector} from "ethereum-vault-connector//EthereumVaultConnector.sol";
+import {
+    PositionManager, IAllowanceTransfer, IPositionDescriptor, IWETH9
+} from "lib/v4-periphery/src/PositionManager.sol";
+import {WETH} from "lib/solady/src/tokens/WETH.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {LiquidityHelper} from "src/periphery/LiquidityHelper.sol";
+
+contract AssetToAssetSwapHookTest is YieldHarvestingHookTest {
+    PositionManager public positionManager;
+    address public weth;
+    address public evc;
+    AssetToAssetSwapHookForERC4626 assetToAssetSwapHook;
+    LiquidityHelper liquidityHelper;
+
+    address initialOwner = makeAddr("initialOwner");
+
+    using StateLibrary for PoolManager;
+
+    uint160 constant SWAP_HOOK_PERMISSIONS =
+        uint160(Hooks.BEFORE_SWAP_FLAG) | uint160(Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG);
+
+    PoolKey assetsPoolKey;
+    PoolKey mixedAssetPoolKey;
+
+    function setUp() public override {
+        super.setUp();
+
+        evc = address(new EthereumVaultConnector());
+        weth = address(new WETH());
+        positionManager = new PositionManager(
+            poolManager, IAllowanceTransfer(address(0)), 0, IPositionDescriptor(address(0)), IWETH9(address(weth))
+        );
+
+        setUpVaults(false);
+
+        (uint160 sqrtRatioX96,,,) = poolManager.getSlot0(poolKey.toId());
+
+        ModifyLiquidityParams memory liquidityParams = ModifyLiquidityParams({
+            tickLower: TickMath.minUsableTick(poolKey.tickSpacing),
+            tickUpper: TickMath.maxUsableTick(poolKey.tickSpacing),
+            liquidityDelta: 1e20,
+            salt: keccak256(abi.encodePacked(address(this), SWAP_HOOK_PERMISSIONS))
+        });
+
+        modifyLiquidity(liquidityParams, sqrtRatioX96);
+
+        modifyMixedLiquidity(liquidityParams, sqrtRatioX96);
+
+        Currency currency0 =
+            address(asset0) < address(asset1) ? Currency.wrap(address(asset0)) : Currency.wrap(address(asset1));
+
+        bool isCurrency0SameAsAsset0 = currency0 == Currency.wrap(address(asset0));
+
+        (, bytes32 salt) = HookMiner.find(
+            address(this),
+            SWAP_HOOK_PERMISSIONS,
+            type(AssetToAssetSwapHookForERC4626).creationCode,
+            abi.encode(poolManager, yieldHarvestingHook, initialOwner)
+        );
+
+        assetToAssetSwapHook =
+            new AssetToAssetSwapHookForERC4626{salt: salt}(poolManager, yieldHarvestingHook, initialOwner);
+
+        liquidityHelper = new LiquidityHelper(evc, positionManager, yieldHarvestingHook);
+
+        assetsPoolKey = PoolKey({
+            currency0: isCurrency0SameAsAsset0 ? Currency.wrap(address(asset0)) : Currency.wrap(address(asset1)),
+            currency1: isCurrency0SameAsAsset0 ? Currency.wrap(address(asset1)) : Currency.wrap(address(asset0)),
+            fee: poolKey.fee,
+            tickSpacing: poolKey.tickSpacing,
+            hooks: assetToAssetSwapHook
+        });
+
+        poolManager.initialize(assetsPoolKey, Constants.SQRT_PRICE_1_1);
+    }
+
+    function _currencyToIERC20(Currency currency) internal pure returns (IERC20) {
+        return IERC20(Currency.unwrap(currency));
+    }
+
+    function sortVaultWrappers(IERC4626 vaultWrapperA, IERC4626 vaultWrapperB, address asset0, address asset1)
+        internal
+        view
+        returns (IERC4626 vaultWrapper0, IERC4626 vaultWrapper1)
+    {
+        IERC4626 underlyingVaultA = IERC4626(vaultWrapperA.asset());
+        IERC4626 underlyingVaultB = IERC4626(vaultWrapperB.asset());
+
+        if (underlyingVaultA.asset() == asset0 && underlyingVaultB.asset() == asset1) {
+            return (vaultWrapperA, vaultWrapperB);
+        } else if (underlyingVaultA.asset() == asset1 && underlyingVaultB.asset() == asset0) {
+            return (vaultWrapperB, vaultWrapperA);
+        } else {
+            revert("Vault wrappers do not wrap the correct assets");
+        }
+    }
+
+    function test_setDefaultVaultWrappers() public {
+        vm.expectRevert();
+        assetToAssetSwapHook.setDefaultVaultWrappers(assetsPoolKey, IERC4626(address(0)), IERC4626(address(0)));
+
+        (IERC4626 associatedVault0, IERC4626 associatedVault1) =
+            sortVaultWrappers(vaultWrapper0, vaultWrapper1, address(asset0), address(asset1));
+
+        vm.startPrank(initialOwner);
+        assetToAssetSwapHook.setDefaultVaultWrappers(assetsPoolKey, associatedVault0, associatedVault1);
+    }
+
+    function test_assetsSwapExactAmountIn(uint256 amountIn, bool zeroForOne) public {
+        amountIn = bound(amountIn, 10, 1e18);
+
+        Currency currencyIn = zeroForOne ? assetsPoolKey.currency0 : assetsPoolKey.currency1;
+        Currency currencyOut = zeroForOne ? assetsPoolKey.currency1 : assetsPoolKey.currency0;
+
+        deal(Currency.unwrap(currencyIn), address(this), amountIn);
+        _currencyToIERC20(currencyIn).approve(address(swapRouter), amountIn);
+
+        //we assume that prior to the mint, poolManager already has some asset0 that user can take it out of
+        deal(Currency.unwrap(currencyIn), address(poolManager), amountIn);
+
+        uint256 assetBalanceBefore = currencyOut.balanceOf(address(this));
+
+        SwapParams memory swapParams = SwapParams({
+            zeroForOne: zeroForOne,
+            amountSpecified: -int256(amountIn),
+            sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+        });
+
+        (IERC4626 associatedVault0, IERC4626 associatedVault1) = sortVaultWrappers(
+            vaultWrapper0,
+            vaultWrapper1,
+            Currency.unwrap(assetsPoolKey.currency0),
+            Currency.unwrap(assetsPoolKey.currency1)
+        );
+
+        BalanceDelta swapDelta = swapRouter.swap(
+            assetsPoolKey,
+            swapParams,
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
+            abi.encode(associatedVault0, associatedVault1)
+        );
+
+        uint256 assetOut = SafeCast.toUint256(zeroForOne ? swapDelta.amount1() : swapDelta.amount0());
+        assertEq(assetOut, currencyOut.balanceOf(address(this)) - assetBalanceBefore, "Incorrect asset out amount");
+    }
+
+    function test_assetsSwapExactAmountOut(uint256 amountOut, bool zeroForOne) public {
+        amountOut = bound(amountOut, 10, 1e18);
+
+        Currency currencyIn = zeroForOne ? assetsPoolKey.currency0 : assetsPoolKey.currency1;
+        Currency currencyOut = zeroForOne ? assetsPoolKey.currency1 : assetsPoolKey.currency0;
+
+        deal(Currency.unwrap(currencyIn), address(this), 2 * amountOut);
+        _currencyToIERC20(currencyIn).approve(address(swapRouter), 2 * amountOut);
+
+        //we assume that prior to the swap, poolManager already has some asset1 that user can take it out of
+        deal(Currency.unwrap(currencyIn), address(poolManager), 2 * amountOut);
+
+        uint256 assetBalanceBefore = currencyIn.balanceOf(address(this));
+
+        SwapParams memory swapParams = SwapParams({
+            zeroForOne: zeroForOne,
+            amountSpecified: int256(amountOut),
+            sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1
+        });
+
+        (IERC4626 associatedVault0, IERC4626 associatedVault1) =
+            sortVaultWrappers(vaultWrapper0, vaultWrapper1, address(asset0), address(asset1));
+
+        vm.startPrank(initialOwner);
+        assetToAssetSwapHook.setDefaultVaultWrappers(assetsPoolKey, associatedVault0, associatedVault1);
+        vm.stopPrank();
+
+        BalanceDelta swapDelta = swapRouter.swap(
+            assetsPoolKey, swapParams, PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}), ""
+        );
+
+        uint256 assetIn = SafeCast.toUint256(zeroForOne ? -swapDelta.amount0() : -swapDelta.amount1());
+        assertEq(assetIn, assetBalanceBefore - currencyIn.balanceOf(address(this)), "Incorrect asset out amount");
+    }
+
+    function testMintAndIncreasePosition(uint128 liquidityToAdd) public {
+        liquidityToAdd = uint128(bound(liquidityToAdd, 1, 1e18));
+
+        int24 tickUpper = TickMath.maxUsableTick(poolKey.tickSpacing);
+        int24 tickLower = TickMath.minUsableTick(poolKey.tickSpacing);
+
+        deal(address(asset0), address(this), liquidityToAdd);
+        deal(address(asset1), address(this), liquidityToAdd);
+
+        asset0.approve(address(liquidityHelper), type(uint256).max);
+        asset1.approve(address(liquidityHelper), type(uint256).max);
+
+        poolKey.currency0 = Currency.wrap(address(asset0));
+        poolKey.currency1 = Currency.wrap(address(asset1));
+
+        (uint256 tokenId) = liquidityHelper.mintPosition(
+            poolKey,
+            tickLower,
+            tickUpper,
+            liquidityToAdd,
+            uint128(liquidityToAdd),
+            uint128(liquidityToAdd),
+            address(this),
+            abi.encode(vaultWrapper0, vaultWrapper1)
+        );
+
+        deal(address(asset0), address(this), liquidityToAdd);
+        deal(address(asset1), address(this), liquidityToAdd);
+
+        positionManager.approve(address(liquidityHelper), tokenId);
+
+        liquidityHelper.increaseLiquidity(
+            poolKey,
+            tokenId,
+            liquidityToAdd,
+            uint128(liquidityToAdd),
+            uint128(liquidityToAdd),
+            abi.encode(vaultWrapper0, vaultWrapper1)
+        );
+
+        liquidityHelper.decreaseLiquidity(
+            poolKey, tokenId, liquidityToAdd, 0, 0, address(this), abi.encode(vaultWrapper0, vaultWrapper1)
+        );
+    }
+}

--- a/test/periphery/Base/BaseAssetToVaultWrapperHelper.t.sol
+++ b/test/periphery/Base/BaseAssetToVaultWrapperHelper.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.26;
+
+import {ERC4626VaultWrapper} from "src/vaultWrappers/ERC4626VaultWrapper.sol";
+import {BaseVaultWrapper} from "src/vaultWrappers/base/BaseVaultWrapper.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {ERC4626} from "solmate/src/mixins/ERC4626.sol";
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "test/utils/MockERC20.sol";
+import {MockERC4626} from "test/utils/MockERC4626.sol";
+import {BaseAssetToVaultWrapperHelper} from "src/periphery/base/BaseAssetToVaultWrapperHelper.sol";
+import {IERC4626} from "lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import {LibClone} from "lib/solady/src/utils/LibClone.sol";
+import {ERC4626VaultWrapperTest} from "test/ERC4626VaultWrapper.t.sol";
+
+contract MockAssetToVaultWrapperHelper is BaseAssetToVaultWrapperHelper {
+    function deposit(
+        IERC4626 vaultWrapper,
+        address underlyingVault,
+        IERC20 asset,
+        address from,
+        uint256 amount,
+        address receiver
+    ) external returns (uint256) {
+        return _deposit(vaultWrapper, underlyingVault, asset, from, amount, receiver);
+    }
+
+    function redeem(IERC4626 vaultWrapper, address underlyingVault, address from, uint256 amount, address receiver)
+        external
+        returns (uint256)
+    {
+        return _redeem(vaultWrapper, underlyingVault, from, amount, receiver);
+    }
+
+    function mint(
+        IERC4626 vaultWrapper,
+        address underlyingVault,
+        IERC20 asset,
+        address from,
+        uint256 amount,
+        address receiver
+    ) external returns (uint256) {
+        return _mint(vaultWrapper, underlyingVault, asset, from, amount, receiver);
+    }
+
+    function withdraw(IERC4626 vaultWrapper, address underlyingVault, address from, uint256 amount, address receiver)
+        external
+        returns (uint256)
+    {
+        return _withdraw(vaultWrapper, underlyingVault, from, amount, receiver);
+    }
+}
+
+contract AssetToVaultWrapperHelper is Test {
+    MockERC20 underlyingAsset;
+    MockERC4626 underlyingVault;
+    ERC4626VaultWrapper vaultWrapper;
+    MockAssetToVaultWrapperHelper assetToVaultWrapperHelper;
+
+    address harvester = makeAddr("harvester");
+    address user = makeAddr("user");
+    address receiver = makeAddr("receiver");
+
+    function setUp() public {
+        underlyingAsset = new MockERC20();
+        underlyingVault = new MockERC4626(underlyingAsset);
+        vaultWrapper = ERC4626VaultWrapper(
+            LibClone.cloneDeterministic(
+                address(new ERC4626VaultWrapper()),
+                abi.encodePacked(address(this), harvester, address(underlyingVault)),
+                keccak256(abi.encodePacked(address(underlyingVault)))
+            )
+        );
+
+        assetToVaultWrapperHelper = new MockAssetToVaultWrapperHelper();
+    }
+
+    function _depositForUser(uint256 amount, address from, address to) internal returns (uint256 sharesReceived) {
+        vm.startPrank(from);
+        underlyingAsset.approve(address(assetToVaultWrapperHelper), amount);
+        sharesReceived = assetToVaultWrapperHelper.deposit(
+            vaultWrapper, address(underlyingVault), IERC20(address(underlyingAsset)), from, amount, to
+        );
+        vm.stopPrank();
+    }
+
+    function test_deposit(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        underlyingAsset.mint(user, amount);
+
+        uint256 userInitialBalance = underlyingAsset.balanceOf(user);
+        uint256 receiverInitialBalance = vaultWrapper.balanceOf(receiver);
+
+        uint256 sharesReceived = _depositForUser(amount, user, receiver);
+
+        assertEq(underlyingAsset.balanceOf(user), userInitialBalance - amount);
+        assertEq(vaultWrapper.balanceOf(receiver), receiverInitialBalance + sharesReceived);
+    }
+
+    function test_redeem(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        underlyingAsset.mint(user, amount);
+
+        uint256 sharesReceived = _depositForUser(amount, user, user);
+
+        uint256 receiverInitialBalance = underlyingAsset.balanceOf(receiver);
+        uint256 userInitialBalance = vaultWrapper.balanceOf(user);
+
+        vm.startPrank(user);
+        vaultWrapper.approve(address(assetToVaultWrapperHelper), sharesReceived);
+        uint256 assetsReceived =
+            assetToVaultWrapperHelper.redeem(vaultWrapper, address(underlyingVault), user, sharesReceived, receiver);
+        vm.stopPrank();
+
+        assertEq(underlyingAsset.balanceOf(receiver), receiverInitialBalance + assetsReceived);
+        assertEq(vaultWrapper.balanceOf(user), userInitialBalance - sharesReceived);
+    }
+
+    function test_mint(uint256 shares) public {
+        shares = bound(shares, 1, type(uint128).max);
+
+        uint256 underlyingVaultSharesRequired = vaultWrapper.previewMint(shares);
+        uint256 assetsRequired = underlyingVault.previewMint(underlyingVaultSharesRequired);
+        underlyingAsset.mint(user, assetsRequired);
+
+        uint256 userInitialBalance = underlyingAsset.balanceOf(user);
+        uint256 receiverInitialBalance = vaultWrapper.balanceOf(receiver);
+
+        vm.startPrank(user);
+        underlyingAsset.approve(address(assetToVaultWrapperHelper), assetsRequired);
+        uint256 actualAssetsRequired = assetToVaultWrapperHelper.mint(
+            vaultWrapper, address(underlyingVault), IERC20(address(underlyingAsset)), user, shares, receiver
+        );
+        vm.stopPrank();
+
+        assertEq(actualAssetsRequired, assetsRequired);
+        assertEq(underlyingAsset.balanceOf(user), userInitialBalance - assetsRequired);
+        assertEq(vaultWrapper.balanceOf(receiver), receiverInitialBalance + shares);
+    }
+
+    function test_withdraw(uint256 assets) public {
+        assets = bound(assets, 1, type(uint128).max);
+        underlyingAsset.mint(user, assets);
+
+        uint256 sharesReceived = _depositForUser(assets, user, user);
+
+        uint256 receiverInitialBalance = underlyingAsset.balanceOf(receiver);
+        uint256 userInitialBalance = vaultWrapper.balanceOf(user);
+
+        vm.startPrank(user);
+        vaultWrapper.approve(address(assetToVaultWrapperHelper), sharesReceived);
+        uint256 assetsWithdrawn =
+            assetToVaultWrapperHelper.withdraw(vaultWrapper, address(underlyingVault), user, assets, receiver);
+        vm.stopPrank();
+
+        assertEq(assetsWithdrawn, assets);
+        assertEq(underlyingAsset.balanceOf(receiver), receiverInitialBalance + assetsWithdrawn);
+        assertEq(vaultWrapper.balanceOf(user), userInitialBalance - sharesReceived);
+    }
+}


### PR DESCRIPTION
AssetToAssetSwapHook - A hook that takes care of conversion to and from vault wrappers. Users can provide raw asset and get the raw asset back

LiquidityHelper - Add liquidity to a pools with the yield harvesting hook. The helper contract takes care of the conversion to and from vault wrappers in this case as well